### PR TITLE
The plugin should work both when running "sls offline" and "sls offline start"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ class ServerlessLocalKinesis {
 
     this.hooks = {
       'before:offline:start': this.run.bind(this),
+      'before:offline:start:init': this.run.bind(this),
     };
   }
 


### PR DESCRIPTION
Fixes serverless offline hook and closes #2 .